### PR TITLE
Add configurable hourly rotated file logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +579,15 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1436,6 +1454,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1719,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2361,6 +2391,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2598,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3236,6 +3309,7 @@ dependencies = [
  "tokio-tungstenite",
  "toml 0.8.23",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ toml = "0.8"
 # 日志系统
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 
 # 指标收集
 metrics = "0.21"

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ log_level = "info"
 
 [log]
 # Rolling log file destination (hourly rotation, local time, files named like xtrade-YYYY-MM-DD-HH.log)
-file_path = "logs/xtrade.log"
+file_path = "logs"
 
 [binance]
 # Binance WebSocket URL

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,10 @@ enable_sparkline = true
 # Logging level (trace, debug, info, warn, error)
 log_level = "info"
 
+[log]
+# Rolling log file destination (hourly rotation)
+file_path = "logs/xtrade.log"
+
 [binance]
 # Binance WebSocket URL
 ws_url = "wss://stream.binance.com:9443"

--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ enable_sparkline = true
 log_level = "info"
 
 [log]
-# Rolling log file destination (hourly rotation)
+# Rolling log file destination (hourly rotation, local time, files named like xtrade-YYYY-MM-DD-HH.log)
 file_path = "logs/xtrade.log"
 
 [binance]

--- a/config.toml.example
+++ b/config.toml.example
@@ -17,7 +17,7 @@ enable_sparkline = true
 log_level = "info"
 
 [log]
-# Rolling log file destination (hourly rotation)
+# Rolling log file destination (hourly rotation, local time, files named like xtrade-YYYY-MM-DD-HH.log)
 file_path = "logs/xtrade.log"
 
 [binance]

--- a/config.toml.example
+++ b/config.toml.example
@@ -18,7 +18,7 @@ log_level = "info"
 
 [log]
 # Rolling log file destination (hourly rotation, local time, files named like xtrade-YYYY-MM-DD-HH.log)
-file_path = "logs/xtrade.log"
+file_path = "/var/log"
 
 [binance]
 # Binance WebSocket URL

--- a/config.toml.example
+++ b/config.toml.example
@@ -16,6 +16,10 @@ enable_sparkline = true
 # Logging level (trace, debug, info, warn, error)
 log_level = "info"
 
+[log]
+# Rolling log file destination (hourly rotation)
+file_path = "logs/xtrade.log"
+
 [binance]
 # Binance WebSocket URL
 ws_url = "wss://stream.binance.com:9443"

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -363,7 +363,7 @@ refresh_rate_ms = 500
 log_level = "info"
 
 [log]
-file_path = "logs/xtrade.log"
+file_path = "logs"
 ```
 
 #### High-Frequency Trading Configuration
@@ -405,7 +405,7 @@ export XTRADE_ORDERBOOK_DEPTH=25
 export XTRADE_LOG_LEVEL=debug
 
 # Log file location (hourly rotation)
-export XTRADE_LOG_FILE_PATH=/var/log/xtrade/xtrade.log
+export XTRADE_LOG_FILE_PATH=/var/log
 
 # Binance WebSocket URL
 export XTRADE_BINANCE_WS_URL=wss://stream.binance.com:9443

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -335,7 +335,7 @@ sparkline_points = 60
 - `orderbook_depth`: Number of price levels to display in orderbook (10-50)
 - `enable_sparkline`: Enable/disable price sparkline charts
 - `log_level`: Logging verbosity level
-- `log.file_path`: Destination for file-based logs. Files are rotated hourly with the pattern `<file>.<YYYY-MM-DD-HH>`.
+- `log.file_path`: Destination for file-based logs. Files are rotated hourly using local time with the pattern `<prefix>-<YYYY-MM-DD-HH><suffix>` (defaults to `xtrade-YYYY-MM-DD-HH.log`).
 
 #### Binance Settings
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -335,6 +335,7 @@ sparkline_points = 60
 - `orderbook_depth`: Number of price levels to display in orderbook (10-50)
 - `enable_sparkline`: Enable/disable price sparkline charts
 - `log_level`: Logging verbosity level
+- `log.file_path`: Destination for file-based logs. Files are rotated hourly with the pattern `<file>.<YYYY-MM-DD-HH>`.
 
 #### Binance Settings
 
@@ -360,6 +361,9 @@ sparkline_points = 60
 symbols = ["BTCUSDT"]
 refresh_rate_ms = 500
 log_level = "info"
+
+[log]
+file_path = "logs/xtrade.log"
 ```
 
 #### High-Frequency Trading Configuration
@@ -399,6 +403,9 @@ export XTRADE_ORDERBOOK_DEPTH=25
 
 # Log level
 export XTRADE_LOG_LEVEL=debug
+
+# Log file location (hourly rotation)
+export XTRADE_LOG_FILE_PATH=/var/log/xtrade/xtrade.log
 
 # Binance WebSocket URL
 export XTRADE_BINANCE_WS_URL=wss://stream.binance.com:9443

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,22 +11,116 @@ pub mod metrics;
 pub mod session;
 pub mod ui;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::config::LogConfig;
 
 /// Application result type for consistent error handling
 pub type AppResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 /// Initialize tracing subscriber for logging
-pub fn init_logging(level: &str) -> Result<()> {
+pub fn init_logging(level: &str, log_config: &LogConfig) -> Result<()> {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    let (directory, file_prefix) = resolve_log_destination(&log_config.file_path);
+
+    std::fs::create_dir_all(&directory)
+        .with_context(|| format!("Failed to create log directory: {}", directory.display()))?;
+
+    let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
+        .rotation(tracing_appender::rolling::Rotation::HOURLY)
+        .filename_prefix(file_prefix.clone())
+        .build(&directory)
+        .with_context(|| {
+            format!(
+                "Failed to initialize hourly log file writer at {}/{}",
+                directory.display(),
+                file_prefix
+            )
+        })?;
 
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| format!("xtrade={}", level).into()),
         )
-        .with(tracing_subscriber::fmt::layer())
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(file_appender)
+                .with_ansi(false),
+        )
         .init();
 
     Ok(())
+}
+
+fn resolve_log_destination(path: &str) -> (PathBuf, String) {
+    let requested = Path::new(path);
+
+    let treat_as_directory = path.ends_with('/')
+        || path.ends_with('\\')
+        || requested.file_name().is_none()
+        || matches!(
+            requested.file_name().and_then(|f| f.to_str()),
+            Some(".") | Some("..")
+        );
+
+    if treat_as_directory {
+        let directory = if path.trim().is_empty() {
+            PathBuf::from(".")
+        } else {
+            requested.to_path_buf()
+        };
+        return (directory, "xtrade.log".to_string());
+    }
+
+    if let Some(file_name) = requested.file_name().and_then(|f| {
+        let name = f.to_string_lossy();
+        if name.is_empty() {
+            None
+        } else {
+            Some(name.to_string())
+        }
+    }) {
+        let directory = requested
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        (directory, file_name)
+    } else {
+        (requested.to_path_buf(), "xtrade.log".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_log_destination;
+    use std::path::PathBuf;
+
+    #[test]
+    fn defaults_to_current_directory_when_path_is_empty() {
+        let (directory, file_name) = resolve_log_destination("");
+
+        assert_eq!(directory, PathBuf::from("."));
+        assert_eq!(file_name, "xtrade.log");
+    }
+
+    #[test]
+    fn preserves_explicit_file_name() {
+        let (directory, file_name) = resolve_log_destination("/var/log/xtrade/output.log");
+
+        assert_eq!(directory, PathBuf::from("/var/log/xtrade"));
+        assert_eq!(file_name, "output.log");
+    }
+
+    #[test]
+    fn treats_directory_paths_as_log_roots() {
+        let (directory, file_name) = resolve_log_destination("logs/");
+
+        assert_eq!(directory, PathBuf::from("logs/"));
+        assert_eq!(file_name, "xtrade.log");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod session;
 pub mod ui;
 
 use anyhow::{Context, Result};
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::config::LogConfig;
@@ -23,7 +24,7 @@ pub type AppResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 pub fn init_logging(level: &str, log_config: &LogConfig) -> Result<()> {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-    let (directory, file_prefix) = resolve_log_destination(&log_config.file_path);
+    let (directory, file_prefix, file_suffix) = resolve_log_destination(&log_config.file_path);
 
     std::fs::create_dir_all(&directory)
         .with_context(|| format!("Failed to create log directory: {}", directory.display()))?;
@@ -31,12 +32,14 @@ pub fn init_logging(level: &str, log_config: &LogConfig) -> Result<()> {
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::HOURLY)
         .filename_prefix(file_prefix.clone())
+        .filename_suffix(file_suffix.clone())
         .build(&directory)
         .with_context(|| {
             format!(
-                "Failed to initialize hourly log file writer at {}/{}",
+                "Failed to initialize hourly log file writer at {}/{}-{{timestamp}}{}",
                 directory.display(),
-                file_prefix
+                file_prefix,
+                file_suffix
             )
         })?;
 
@@ -48,14 +51,15 @@ pub fn init_logging(level: &str, log_config: &LogConfig) -> Result<()> {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(file_appender)
-                .with_ansi(false),
+                .with_ansi(false)
+                .with_timer(LocalTimer),
         )
         .init();
 
     Ok(())
 }
 
-fn resolve_log_destination(path: &str) -> (PathBuf, String) {
+fn resolve_log_destination(path: &str) -> (PathBuf, String, String) {
     let requested = Path::new(path);
 
     let treat_as_directory = path.ends_with('/')
@@ -72,7 +76,7 @@ fn resolve_log_destination(path: &str) -> (PathBuf, String) {
         } else {
             requested.to_path_buf()
         };
-        return (directory, "xtrade.log".to_string());
+        return (directory, "xtrade".to_string(), ".log".to_string());
     }
 
     if let Some(file_name) = requested.file_name().and_then(|f| {
@@ -89,9 +93,39 @@ fn resolve_log_destination(path: &str) -> (PathBuf, String) {
             .map(Path::to_path_buf)
             .unwrap_or_else(|| PathBuf::from("."));
 
-        (directory, file_name)
+        let (prefix, suffix) = split_prefix_suffix(&file_name);
+
+        (directory, prefix, suffix)
     } else {
-        (requested.to_path_buf(), "xtrade.log".to_string())
+        (
+            requested.to_path_buf(),
+            "xtrade".to_string(),
+            ".log".to_string(),
+        )
+    }
+}
+
+fn split_prefix_suffix(file_name: &str) -> (String, String) {
+    if let Some((prefix, extension)) = file_name.rsplit_once('.') {
+        if !prefix.is_empty() && !extension.is_empty() {
+            return (prefix.to_string(), format!(".{extension}"));
+        }
+    }
+
+    if file_name.is_empty() {
+        return ("xtrade".to_string(), ".log".to_string());
+    }
+
+    (file_name.to_string(), ".log".to_string())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LocalTimer;
+
+impl tracing_subscriber::fmt::time::FormatTime for LocalTimer {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
+        let now = chrono::Local::now();
+        write!(w, "{}", now.format("%Y-%m-%d %H:%M:%S%.3f"))
     }
 }
 
@@ -102,25 +136,38 @@ mod tests {
 
     #[test]
     fn defaults_to_current_directory_when_path_is_empty() {
-        let (directory, file_name) = resolve_log_destination("");
+        let (directory, file_prefix, file_suffix) = resolve_log_destination("");
 
         assert_eq!(directory, PathBuf::from("."));
-        assert_eq!(file_name, "xtrade.log");
+        assert_eq!(file_prefix, "xtrade");
+        assert_eq!(file_suffix, ".log");
     }
 
     #[test]
     fn preserves_explicit_file_name() {
-        let (directory, file_name) = resolve_log_destination("/var/log/xtrade/output.log");
+        let (directory, file_prefix, file_suffix) =
+            resolve_log_destination("/var/log/xtrade/output.log");
 
         assert_eq!(directory, PathBuf::from("/var/log/xtrade"));
-        assert_eq!(file_name, "output.log");
+        assert_eq!(file_prefix, "output");
+        assert_eq!(file_suffix, ".log");
     }
 
     #[test]
     fn treats_directory_paths_as_log_roots() {
-        let (directory, file_name) = resolve_log_destination("logs/");
+        let (directory, file_prefix, file_suffix) = resolve_log_destination("logs/");
 
         assert_eq!(directory, PathBuf::from("logs/"));
-        assert_eq!(file_name, "xtrade.log");
+        assert_eq!(file_prefix, "xtrade");
+        assert_eq!(file_suffix, ".log");
+    }
+
+    #[test]
+    fn defaults_suffix_when_missing_extension() {
+        let (directory, file_prefix, file_suffix) = resolve_log_destination("/tmp/xtrade_output");
+
+        assert_eq!(directory, PathBuf::from("/tmp"));
+        assert_eq!(file_prefix, "xtrade_output");
+        assert_eq!(file_suffix, ".log");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@ pub mod session;
 pub mod ui;
 
 use anyhow::{Context, Result};
-use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
 
 use crate::config::LogConfig;
 
@@ -23,23 +21,18 @@ pub type AppResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 /// Initialize tracing subscriber for logging
 pub fn init_logging(level: &str, log_config: &LogConfig) -> Result<()> {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-    let (directory, file_prefix, file_suffix) = resolve_log_destination(&log_config.file_path);
-
-    std::fs::create_dir_all(&directory)
-        .with_context(|| format!("Failed to create log directory: {}", directory.display()))?;
+    let directory = &log_config.file_path;
+    std::fs::create_dir_all(directory)
+        .with_context(|| format!("Failed to create log directory: {}", directory))?;
 
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::HOURLY)
-        .filename_prefix(file_prefix.clone())
-        .filename_suffix(file_suffix.clone())
-        .build(&directory)
+        .filename_prefix("xtrade.log")
+        .build(directory)
         .with_context(|| {
             format!(
-                "Failed to initialize hourly log file writer at {}/{}-{{timestamp}}{}",
-                directory.display(),
-                file_prefix,
-                file_suffix
+                "Failed to initialize hourly log file writer at {}",
+                directory
             )
         })?;
 
@@ -59,66 +52,6 @@ pub fn init_logging(level: &str, log_config: &LogConfig) -> Result<()> {
     Ok(())
 }
 
-fn resolve_log_destination(path: &str) -> (PathBuf, String, String) {
-    let requested = Path::new(path);
-
-    let treat_as_directory = path.ends_with('/')
-        || path.ends_with('\\')
-        || requested.file_name().is_none()
-        || matches!(
-            requested.file_name().and_then(|f| f.to_str()),
-            Some(".") | Some("..")
-        );
-
-    if treat_as_directory {
-        let directory = if path.trim().is_empty() {
-            PathBuf::from(".")
-        } else {
-            requested.to_path_buf()
-        };
-        return (directory, "xtrade".to_string(), ".log".to_string());
-    }
-
-    if let Some(file_name) = requested.file_name().and_then(|f| {
-        let name = f.to_string_lossy();
-        if name.is_empty() {
-            None
-        } else {
-            Some(name.to_string())
-        }
-    }) {
-        let directory = requested
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| PathBuf::from("."));
-
-        let (prefix, suffix) = split_prefix_suffix(&file_name);
-
-        (directory, prefix, suffix)
-    } else {
-        (
-            requested.to_path_buf(),
-            "xtrade".to_string(),
-            ".log".to_string(),
-        )
-    }
-}
-
-fn split_prefix_suffix(file_name: &str) -> (String, String) {
-    if let Some((prefix, extension)) = file_name.rsplit_once('.') {
-        if !prefix.is_empty() && !extension.is_empty() {
-            return (prefix.to_string(), format!(".{extension}"));
-        }
-    }
-
-    if file_name.is_empty() {
-        return ("xtrade".to_string(), ".log".to_string());
-    }
-
-    (file_name.to_string(), ".log".to_string())
-}
-
 #[derive(Debug, Clone, Copy)]
 struct LocalTimer;
 
@@ -126,48 +59,5 @@ impl tracing_subscriber::fmt::time::FormatTime for LocalTimer {
     fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
         let now = chrono::Local::now();
         write!(w, "{}", now.format("%Y-%m-%d %H:%M:%S%.3f"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::resolve_log_destination;
-    use std::path::PathBuf;
-
-    #[test]
-    fn defaults_to_current_directory_when_path_is_empty() {
-        let (directory, file_prefix, file_suffix) = resolve_log_destination("");
-
-        assert_eq!(directory, PathBuf::from("."));
-        assert_eq!(file_prefix, "xtrade");
-        assert_eq!(file_suffix, ".log");
-    }
-
-    #[test]
-    fn preserves_explicit_file_name() {
-        let (directory, file_prefix, file_suffix) =
-            resolve_log_destination("/var/log/xtrade/output.log");
-
-        assert_eq!(directory, PathBuf::from("/var/log/xtrade"));
-        assert_eq!(file_prefix, "output");
-        assert_eq!(file_suffix, ".log");
-    }
-
-    #[test]
-    fn treats_directory_paths_as_log_roots() {
-        let (directory, file_prefix, file_suffix) = resolve_log_destination("logs/");
-
-        assert_eq!(directory, PathBuf::from("logs/"));
-        assert_eq!(file_prefix, "xtrade");
-        assert_eq!(file_suffix, ".log");
-    }
-
-    #[test]
-    fn defaults_suffix_when_missing_extension() {
-        let (directory, file_prefix, file_suffix) = resolve_log_destination("/tmp/xtrade_output");
-
-        assert_eq!(directory, PathBuf::from("/tmp"));
-        assert_eq!(file_prefix, "xtrade_output");
-        assert_eq!(file_suffix, ".log");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,22 +11,22 @@ use xtrade::{
 async fn main() -> AppResult<()> {
     let cli = Cli::parse_args();
 
+    let command = cli.command();
+    let config = Config::load_or_default(&cli.config_file);
+
     // Initialize logging
-    init_logging(&cli.effective_log_level())?;
+    init_logging(&cli.effective_log_level(), &config.log)?;
 
     tracing::info!("XTrade Market Data Monitor starting...");
     tracing::debug!("CLI arguments: {:?}", cli);
 
-    // Get command
-    let command = &cli.command();
     match command {
         Commands::Config { action } => {
-            Config::handle_command(action)?;
+            Config::handle_command(&action)?;
             Ok(())
         }
         Commands::Demo => demo::demo_websocket().await,
         _ => {
-            let config = Config::load_or_default(&cli.config_file);
             let mut session_manager = SessionManager::new(&cli, config)?;
             session_manager.start().await?;
             Ok(())


### PR DESCRIPTION
## Summary
- add a log configuration section and environment override to choose the log file destination
- integrate tracing-appender to provide hourly rotated file logging that ensures directories exist and supports CLI-driven log levels
- document the new logging settings in the default configuration and user guide

## Testing
- cargo test *(fails: unable to download crates.io index in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebcbad6bfc832387c9b3aeb20dbedf